### PR TITLE
Fix keycard permission checking and update package reference

### DIFF
--- a/RemoteKeycard/EventHandlers.cs
+++ b/RemoteKeycard/EventHandlers.cs
@@ -1,9 +1,10 @@
-﻿namespace RemoteKeycard;
+﻿using Exiled.API.Enums;
+
+namespace RemoteKeycard;
 
 using System;
 using Exiled.API.Features;
 using Exiled.Events.EventArgs.Player;
-using Interactables.Interobjects.DoorUtils;
 using Players = Exiled.Events.Handlers.Player;
 
 public class EventHandlers
@@ -51,9 +52,9 @@ public class EventHandlers
                 return;
 
             Log.Debug(
-                $"Allowed: {ev.IsAllowed}, Permission?: {ev.Player.HasKeycardPermission(ev.Door.RequiredPermissions.RequiredPermissions)}, Current Item: ${ev.Player.CurrentItem}");
+                $"Allowed: {ev.IsAllowed}, Permission?: {ev.Player.HasKeycardPermission(ev.Door.KeycardPermissions)}, Current Item: ${ev.Player.CurrentItem}");
 
-            if (!ev.IsAllowed && ev.Player.HasKeycardPermission(ev.Door.RequiredPermissions.RequiredPermissions) &&
+            if (!ev.IsAllowed && ev.Player.HasKeycardPermission(ev.Door.KeycardPermissions) &&
                 !ev.Door.IsLocked)
                 ev.IsAllowed = true;
         }
@@ -94,9 +95,9 @@ public class EventHandlers
                 return;
 
             Log.Debug(
-                $"Allowed: {ev.IsAllowed}, Permission?: {ev.Player.HasKeycardPermission(ev.Generator.Base._requiredPermission)}");
+                $"Allowed: {ev.IsAllowed}, Permission?: {ev.Player.HasKeycardPermission(ev.Generator.KeycardPermissions)}");
 
-            if (!ev.IsAllowed && ev.Player.HasKeycardPermission(ev.Generator.Base._requiredPermission))
+            if (!ev.IsAllowed && ev.Player.HasKeycardPermission(ev.Generator.KeycardPermissions))
                 ev.IsAllowed = true;
         }
         catch (Exception e)
@@ -115,10 +116,10 @@ public class EventHandlers
                 return;
 
             Log.Debug(
-                $"Allowed: {ev.IsAllowed}, Permission?: {ev.Player.HasKeycardPermission(ev.InteractingChamber.Base.RequiredPermissions, true)}");
+                $"Allowed: {ev.IsAllowed}, Permission?: {ev.Player.HasKeycardPermission(ev.InteractingChamber.RequiredPermissions, true)}");
 
             if (!ev.IsAllowed && ev.InteractingChamber != null &&
-                ev.Player.HasKeycardPermission(ev.InteractingChamber.Base.RequiredPermissions, true))
+                ev.Player.HasKeycardPermission(ev.InteractingChamber.RequiredPermissions, true))
                 ev.IsAllowed = true;
         }
         catch (Exception e)

--- a/RemoteKeycard/Extensions.cs
+++ b/RemoteKeycard/Extensions.cs
@@ -1,4 +1,6 @@
-﻿namespace RemoteKeycard;
+﻿using Exiled.API.Enums;
+
+namespace RemoteKeycard;
 
 using System.Linq;
 using CustomPlayerEffects;
@@ -24,7 +26,7 @@ public static class Extensions
             return false;
 
         return requiresAllPermissions
-            ? player.Items.Any(item => item is Keycard keycard && keycard.Base.Permissions.HasFlag(permissions))
-            : player.Items.Any(item => item is Keycard keycard && (keycard.Base.Permissions & permissions) != 0);
+            ? player.Items.Any(item => item is Keycard keycard && keycard.Permissions.HasFlag(permissions))
+            : player.Items.Any(item => item is Keycard keycard && (keycard.Permissions & permissions) != 0);
     }
 }

--- a/RemoteKeycard/RemoteKeycard.csproj
+++ b/RemoteKeycard/RemoteKeycard.csproj
@@ -26,6 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ExMod.Exiled" Version="9.0.1" />
+    <PackageReference Include="ExMod.Exiled" Version="9.6.0-beta7" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Fixed an issue with keycard permission checking logic by updating the code to use the correct `Permissions` property(using exild now).
- Replaced `keycard.Base.Permissions` with `keycard.Permissions` to ensure accurate permission checks.
- Updated the `ExMod.Exiled` package reference from version `9.0.1` to `9.6.0-beta7`.
- version to sl 14.1 public beta